### PR TITLE
Fix escapeContent() for non-WebKit browsers

### DIFF
--- a/src/vdom.js
+++ b/src/vdom.js
@@ -535,10 +535,8 @@ var cito = window.cito || {};
         if (isWebKit) {
             helperDiv.innerText = value;
             value = helperDiv.innerHTML;
-        } else if (isFirefox) {
-            value = value.split('<').join('&lt;').split('>').join('&gt;').split('&').join('&amp;');
         } else {
-            value = value.replace(/</g, '&lt;').replace(/>/g, '&gt;').replace(/&/g, '&amp;');
+            value = value.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
         }
         return value;
     }


### PR DESCRIPTION
In Firefox and not-WebKit browsers, escapeContent returns extra ampersand replacement. Ej: `'<div/>' ` returns `'&amp;lt;div/&amp;gt;'`.
Anyway, 'else' here is doing the same of 'else if (isFirefox)' ? in FF 37.x it is so.
Test in http://jsbin.com/lokihi/2/edit?html,javascript,console