### PR TITLE
Fixed empty tag's error on IE8 with WindowsXP, and insertNode error on tabular elements

### DIFF
--- a/dist/cito.js
+++ b/dist/cito.js
@@ -46,6 +46,10 @@
         return typeof value === 'function';
     }
 
+	function isEmptyTag(tag) {
+		return /br|hr|meta|link|base|img|embed|param|area|col|input/.test(tag);
+	}
+
     function norm(node, oldNode) {
         var type = typeof node;
         if (type === 'string') {
@@ -416,7 +420,7 @@
                 }
                 if (tag) {
                     // TODO close only required tags explicitly
-                    html += '</' + tag + '>';
+                    if (isEmptyTag(tag) === false) html += '</' + tag + '>';
                 }
                 return html;
         }

--- a/dist/cito.js
+++ b/dist/cito.js
@@ -336,6 +336,9 @@
                 domNode = prevNode ? prevNode.nextSibling : domParent.firstChild;
             }
         } else {
+			if('|caption|colgroup|col|thead|tbody|tfoot|tr|th|td|'.indexOf('|' + node['tag'] + '|') > -1){
+				helperDiv = document.createElement('table');
+			}
             helperDiv.innerHTML = html;
             domNode = helperDiv.removeChild(helperDiv.firstChild);
         }


### PR DESCRIPTION
I met two errors in my work with citojs,
one is empty tag's error on IE 8 with Windows XP,
another one occured on tabular elements , cause it's helperDiv was 'DIV'.

I fixed these issuses, and now, it's work very well