### PR TITLE
Add ns support for svg and other custom tags

### DIFF
--- a/src/vdom.js
+++ b/src/vdom.js
@@ -252,6 +252,8 @@
                     default: ns = parentNs; break;
                 }
 
+                if(node.ns) ns = node.ns;
+                
                 var attrs = node.attrs,
                     is = attrs && attrs.is;
                 if (ns) {


### PR DESCRIPTION
Add "ns" property on object definition to use the right NS on tag creation. 
Ex. create a g or rect tag on a svg element.